### PR TITLE
Add advanced location input and map selection

### DIFF
--- a/components/location-input.tsx
+++ b/components/location-input.tsx
@@ -1,0 +1,48 @@
+"use client"
+import { useEffect, useState } from "react"
+import { Input } from "@/components/ui/input"
+
+interface LocationInputProps {
+  id: string
+  value: string
+  onChange: (val: string) => void
+}
+
+export default function LocationInput({ id, value, onChange }: LocationInputProps) {
+  const [suggestions, setSuggestions] = useState<string[]>([])
+
+  useEffect(() => {
+    const handler = setTimeout(async () => {
+      if (value.length < 2) {
+        setSuggestions([])
+        return
+      }
+      try {
+        const res = await fetch("/api/geocode", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ address: value }),
+        })
+        if (res.ok) {
+          const data = await res.json()
+          const opts = data.features.map((f: any) => f.properties.formatted as string)
+          setSuggestions(opts)
+        }
+      } catch {
+        setSuggestions([])
+      }
+    }, 300)
+    return () => clearTimeout(handler)
+  }, [value])
+
+  return (
+    <div>
+      <Input list={`${id}-list`} id={id} value={value} onChange={(e) => onChange(e.target.value)} />
+      <datalist id={`${id}-list`}>
+        {suggestions.map((s, i) => (
+          <option value={s} key={i} />
+        ))}
+      </datalist>
+    </div>
+  )
+}

--- a/components/map-display.tsx
+++ b/components/map-display.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { MapContainer, TileLayer, GeoJSON, Marker, Popup, Tooltip, useMap } from "react-leaflet"
+import { MapContainer, TileLayer, GeoJSON, Marker, Popup, Tooltip, useMap, useMapEvents } from "react-leaflet"
 import type { GeoJSON as GeoJSONType } from "geojson"
 import type { LatLngBoundsExpression } from "leaflet"
 import { useEffect } from "react"
@@ -10,6 +10,7 @@ interface MapDisplayProps {
   displayData: GeoJSONType | null
   markers: { position: [number, number]; popup: string }[]
   travelTime: number
+  onSelectLocation?: (coords: [number, number]) => void
 }
 
 const viennaBounds: LatLngBoundsExpression = [
@@ -30,7 +31,16 @@ function ChangeView({ markers }: { markers: { position: [number, number] }[] }) 
   return null
 }
 
-export default function MapDisplay({ displayData, markers, travelTime }: MapDisplayProps) {
+function ClickHandler({ onSelectLocation }: { onSelectLocation?: (coords: [number, number]) => void }) {
+  useMapEvents({
+    click: (e) => {
+      onSelectLocation && onSelectLocation([e.latlng.lat, e.latlng.lng])
+    },
+  })
+  return null
+}
+
+export default function MapDisplay({ displayData, markers, travelTime, onSelectLocation }: MapDisplayProps) {
   return (
     <MapContainer center={[48.2082, 16.3738]} zoom={12} scrollWheelZoom={true} className="h-full w-full z-0">
       <TileLayer
@@ -38,6 +48,7 @@ export default function MapDisplay({ displayData, markers, travelTime }: MapDisp
         url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
       />
       <ChangeView markers={markers} />
+      <ClickHandler onSelectLocation={onSelectLocation} />
 
       {displayData && (
         <GeoJSON

--- a/lib/IsochroneAPI.ts
+++ b/lib/IsochroneAPI.ts
@@ -1,28 +1,23 @@
 import { ResponseGeoJson, TravelMode } from "@/types";
-import { Polygon, MultiPolygon, GeoJsonObject, FeatureCollection } from "geojson";
 
 export class IsochroneAPI {
   constructor(
-    private address: string,
+    private location: string | [number, number],
     private travelMode: TravelMode,
-    private travelTimeInSeconds: number
-  ) {
-    this.address = address.trim();
-  }
+    private travelTimeInSeconds: number,
+  ) {}
 
   private getGeocode = async () => {
     const res = await fetch("/api/geocode", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        address: this.address,
-        mode: this.travelMode,
-        range: this.travelTimeInSeconds,
-      }),
+      body: JSON.stringify({ address: this.location as string }),
     });
     const data = await res.json();
     if (!res.ok)
-      throw new Error(data.message || `Geocoding failed for "${this.address}"`);
+      throw new Error(
+        data.message || `Geocoding failed for "${this.location as string}"`,
+      );
     const [lon, lat] = data.features[0].geometry.coordinates;
     return {
       coords: [lat, lon] as [number, number],
@@ -30,14 +25,28 @@ export class IsochroneAPI {
     };
   };
 
-  public async getIsochrone():Promise<ResponseGeoJson> {
-    const geocode = await this.getGeocode();
+  private async resolveLocation() {
+    if (Array.isArray(this.location)) {
+      return {
+        coords: this.location as [number, number],
+        name: `${this.location[0]},${this.location[1]}`,
+      };
+    }
+    return await this.getGeocode();
+  }
+
+  public async getIsochrone(): Promise<{
+    geojson: ResponseGeoJson;
+    coords: [number, number];
+    name: string;
+  }> {
+    const geocode = await this.resolveLocation();
     const body = {
       lat: geocode.coords[0],
       lon: geocode.coords[1],
       mode: this.travelMode,
       range: this.travelTimeInSeconds,
-      type: "time"
+      type: "time",
     };
 
     const res = await fetch("/api/isochrone", {
@@ -51,6 +60,7 @@ export class IsochroneAPI {
       throw new Error(errorData.message || "Failed to fetch isochrone");
     }
 
-    return await res.json() as ResponseGeoJson;
+    const geojson = (await res.json()) as ResponseGeoJson;
+    return { geojson, coords: geocode.coords, name: geocode.name };
   }
 }


### PR DESCRIPTION
## Summary
- allow address autocomplete with new `LocationInput`
- enable selecting locations via map clicks
- use slider for travel time
- store and restore map options via query parameters
- support coordinates directly in isochrone API

## Testing
- `npm run lint` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685ed6839240832891b809fc6280eeac