### PR TITLE
Fix SSR Leaflet and show selected location markers

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -206,7 +206,7 @@ export default function IsochroneMapPage() {
     <div className="flex h-screen w-full flex-col lg:flex-row bg-background">
       <Card className="w-full lg:w-[380px] lg:h-full lg:border-r lg:rounded-none flex flex-col">
         <CardHeader>
-          <CardTitle className="text-xl">Vienna Reachable Area</CardTitle>
+          <CardTitle className="text-xl">Reachable Area</CardTitle>
         </CardHeader>
         <CardContent className="flex-grow flex flex-col gap-4 space-y-2 overflow-y-auto">
           <div className="">


### PR DESCRIPTION
## Summary
- avoid importing Leaflet on the server by dynamically configuring icons on the client
- show markers for coordinates as locations are entered
- preserve markers returned with isochrone data

## Testing
- `npm run lint` *(fails: requires interactive setup)*
- `npm run build` *(fails: useSearchParams requires suspense boundary)*

------
https://chatgpt.com/codex/tasks/task_e_685fcd9c8c448328a936720cfbafaa8b